### PR TITLE
Fixing C++ code snipet

### DIFF
--- a/source/slides/04_move.jade
+++ b/source/slides/04_move.jade
@@ -151,7 +151,10 @@ section
     p C++ allows compilers to implement RVO even breaking this rule
 
 section
-    h2 How is RVO implemented by compilers :cxx std::vector<int> get_random_ints(int count);
+    h2 How is RVO implemented by compilers
+    
+    :cxx
+        std::vector<int> get_random_ints(int count);
         // ...
         auto numbers = get_random_ints(1000);
 


### PR DESCRIPTION
The first code snipet in Move Sementics Slide 18 is broken. Here is a screen shot:

![move_snipet](https://cloud.githubusercontent.com/assets/8791438/25537135/f5d2def8-2c45-11e7-938d-319cd14f2e59.png)
