### PR TITLE
Unnecessary include

### DIFF
--- a/source/_posts/namespaces.jade
+++ b/source/_posts/namespaces.jade
@@ -4,4 +4,3 @@ tags:
 categories: slides
 ---
 a.btn.btn-large.btn-primary(href='/advanced-cpp/slides/07_namespaces.html') Slide Show
-include:slides ../slides/07_namespaces.sld


### PR DESCRIPTION
Namespaces post contains Slide include which for me seems unnecessary since the Slide Show contains the rendered content. Or `include:slides` is broken.

![namespaces](https://cloud.githubusercontent.com/assets/8791438/25543890/ead8c2fe-2c60-11e7-95c1-9987da512761.png)
![namespace_slides](https://cloud.githubusercontent.com/assets/8791438/25543891/ead9be52-2c60-11e7-8888-65aab23b2cf0.png)
