### PR TITLE
Unnecessary Slide include for Libraries and API design

### DIFF
--- a/source/_posts/library.jade
+++ b/source/_posts/library.jade
@@ -4,4 +4,3 @@ tags:
 categories: slides
 ---
 a.btn.btn-large.btn-primary(href='/advanced-cpp/slides/08_library.html') Slide Show
-include:slides ../slides/08_library.sld


### PR DESCRIPTION
Libraries and API design post contains Slide include which for me seems unnecessary since the Slide Show contains the rendered content. Or `include:slides` is broken.
![lib](https://cloud.githubusercontent.com/assets/8791438/25544278/7066159c-2c62-11e7-926f-872fcfbbbe4f.png)
