### PR TITLE
Unnecessary Slide include for Error handling slides

### DIFF
--- a/source/_posts/errors.jade
+++ b/source/_posts/errors.jade
@@ -4,4 +4,3 @@ tags:
 categories: slides
 ---
 a.btn.btn-large.btn-primary(href='/advanced-cpp/slides/09_errors.html') Slide Show
-include:slides ../slides/09_errors.sld


### PR DESCRIPTION
Error handling post contains Slide include which for me seems unnecessary since the Slide Show contains the rendered content. Or `include:slides` is broken.
![err_inc](https://cloud.githubusercontent.com/assets/8791438/25552822/5983366c-2cac-11e7-95da-3224e4025482.png)
