### PR TITLE
Code snippet not rendered

### DIFF
--- a/source/slides/10_functional.sld
+++ b/source/slides/10_functional.sld
@@ -49,7 +49,7 @@ section
 +++
 +++ slide
 
-::: snippet  10_functional/sort98.cxx  comparator sort
+::: snippet 10_functional/sort98.cxx comparator sort
 :::
 
 


### PR DESCRIPTION
In Functional C++ Slide 3 has Code snippet that is not rendered. (Maybe because of extra spacing)
![no_code](https://cloud.githubusercontent.com/assets/8791438/25552970/2b90face-2cb0-11e7-8a48-67d5c019ee11.png)
