### PR TITLE
Fix example code for swap

### DIFF
--- a/source/slides/07_namespaces.sld
+++ b/source/slides/07_namespaces.sld
@@ -131,7 +131,7 @@ section
                     // ...
                 }
 
-                void swap(Polynom& l, Polynom& r);
+                friend void swap(Polynom& l, Polynom& r);
             }
 
             int main() {


### PR DESCRIPTION
In order for ADL to find math::swap it [needs to be a friend function](https://stackoverflow.com/questions/5695548/public-friend-swap-member-function/5695855#5695855).
(also tried it out myself it)